### PR TITLE
Add Lavalink starter

### DIFF
--- a/examples/lavalink/Dockerfile
+++ b/examples/lavalink/Dockerfile
@@ -1,0 +1,2 @@
+FROM "fredboat/lavalink:master"
+COPY "application.yml" "/opt/Lavalink/application.yml"

--- a/examples/lavalink/README.md
+++ b/examples/lavalink/README.md
@@ -1,0 +1,17 @@
+# Lavalink Example
+
+This is a [Lavalink](https://github.com/Frederikam/Lavalink) server.
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new?template=https%3A%2F%2Fgithub.com%2Frailwayapp%2Fexamples%2Ftree%2Fmaster%2Fexamples%2Flavalink&envs=PASSWORD&PASSWORDDesc=Password+for+Lavalink)
+
+## ✨ Features
+
+- Java
+
+## 💁‍♀️ How to use
+
+- Connect to your Railway project `railway init`
+- Set the `$PASSWORD` environment variable in your Railway project
+- Edit `application.yml` if needed
+  - It is possible to use `${VAR_NAME}` values in the `application.yml` so you can configure with environment variables on Railway! (That's what we did with `${PASSWORD}`)
+- To run the Docker image locally: `railway run`

--- a/examples/lavalink/README.md
+++ b/examples/lavalink/README.md
@@ -14,3 +14,4 @@ This is a [Lavalink](https://github.com/Frederikam/Lavalink) server.
 - Set the `$PASSWORD` environment variable in your Railway project
 - Edit `application.yml` if needed
   - It is possible to use `${VAR_NAME}` values in the `application.yml` so you can configure with environment variables on Railway! (That's what we did with `${PASSWORD}`)
+- To run the Docker image locally: `railway run`

--- a/examples/lavalink/README.md
+++ b/examples/lavalink/README.md
@@ -14,4 +14,3 @@ This is a [Lavalink](https://github.com/Frederikam/Lavalink) server.
 - Set the `$PASSWORD` environment variable in your Railway project
 - Edit `application.yml` if needed
   - It is possible to use `${VAR_NAME}` values in the `application.yml` so you can configure with environment variables on Railway! (That's what we did with `${PASSWORD}`)
-- To run the Docker image locally: `railway run`

--- a/examples/lavalink/application.yml
+++ b/examples/lavalink/application.yml
@@ -1,0 +1,48 @@
+server: # REST and WS server
+  port: ${PORT}
+  address: 0.0.0.0
+lavalink:
+  server:
+    password: ${PASSWORD}
+    sources:
+      youtube: true
+      bandcamp: true
+      soundcloud: true
+      twitch: true
+      vimeo: true
+      http: true
+      local: false
+    bufferDurationMs: 400
+    youtubePlaylistLoadLimit: 6 # Number of pages at 100 each
+    playerUpdateInterval: 5 # How frequently to send player updates to clients, in seconds
+    youtubeSearchEnabled: true
+    soundcloudSearchEnabled: true
+    gc-warnings: true
+    #ratelimit:
+      #ipBlocks: ["1.0.0.0/8", "..."] # list of ip blocks
+      #excludedIps: ["...", "..."] # ips which should be explicit excluded from usage by lavalink
+      #strategy: "RotateOnBan" # RotateOnBan | LoadBalance | NanoSwitch | RotatingNanoSwitch
+      #searchTriggersFail: true # Whether a search 429 should trigger marking the ip as failing
+      #retryLimit: -1 # -1 = use default lavaplayer value | 0 = infinity | >0 = retry will happen this numbers times
+
+metrics:
+  prometheus:
+    enabled: false
+    endpoint: /metrics
+
+sentry:
+  dsn: ""
+  environment: ""
+#  tags:
+#    some_key: some_value
+#    another_key: another_value
+
+logging:
+  file:
+    max-history: 30
+    max-size: 1GB
+  path: ./logs/
+
+  level:
+    root: INFO
+    lavalink: INFO


### PR DESCRIPTION
I'm not sure if this fits under `starters`, as [Lavalink](https://github.com/Frederikam/Lavalink) is a server, not software for building a server. 

More accurately, Lavalink is:
> Standalone audio sending node based on Lavaplayer and JDA-Audio. Allows for sending audio without it ever reaching any of your shards.

It's used primarily for Discord bots. 