### PR TITLE
remove start:production script from blitz starter

### DIFF
--- a/examples/blitzjs/package.json
+++ b/examples/blitzjs/package.json
@@ -6,7 +6,6 @@
     "start": "blitz start --port ${PORT-3000}",
     "studio": "blitz prisma studio",
     "build": "yarn migrate:deploy && blitz build",
-    "start:production": "blitz start --production --port $PORT",
     "migrate:dev": "blitz prisma migrate dev --preview-feature",
     "migrate:deploy": "blitz prisma migrate deploy --preview-feature",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",


### PR DESCRIPTION
Blitz does not support the `--production` flag on the `start` command. The existing `start` script works fine for production deploys and is what official Blitz examples use as well.

[Docs](https://blitzjs.com/docs/cli-start)

Error when using the flag 👇

<img width="610" alt="error@2x" src="https://user-images.githubusercontent.com/10681116/122338233-7175c480-cf0d-11eb-9f8d-ea14734cd1ce.png">
