### PR TITLE
add code-server starter

### DIFF
--- a/examples/code-server/README.md
+++ b/examples/code-server/README.md
@@ -1,0 +1,13 @@
+---
+title: Code Server
+description: A self-hosted version of code-server from Coder
+buttonSource: https://github.com/cdr/deploy-code-server/blob/main/guides/railway.md
+tags:
+  - coder
+  - vscode
+  - ide
+---
+
+# Code Server Example
+
+This example is maintained by the [Coder](https://coder.com/) team and the source code can be found [here](https://github.com/cdr/deploy-code-server).


### PR DESCRIPTION
This PR adds the [code-server](https://github.com/cdr/deploy-code-server) starter to the starters list.