### PR TITLE
change code-server title

### DIFF
--- a/examples/code-server/README.md
+++ b/examples/code-server/README.md
@@ -10,4 +10,4 @@ tags:
 
 # code-server Example
 
-This example is maintained by the [Coder](https://coder.com/) team and the source code can be found [here](https://github.com/cdr/deploy-code-server).
+This example is maintained by the [Coder](https://coder.com/) team and the source code can be found [here](https://github.com/cdr/code-server).

--- a/examples/code-server/README.md
+++ b/examples/code-server/README.md
@@ -1,5 +1,5 @@
 ---
-title: code-server
+title: Code Server
 description: A self-hosted version of code-server from Coder
 buttonSource: https://github.com/cdr/deploy-code-server/blob/main/guides/railway.md
 tags:

--- a/examples/code-server/README.md
+++ b/examples/code-server/README.md
@@ -1,6 +1,6 @@
 ---
-title: Code Server
-description: A self-hosted version of code-server from Coder
+title: code-server
+description: Self-hosted VS Code in the web browser from Coder.
 buttonSource: https://github.com/cdr/deploy-code-server/blob/main/guides/railway.md
 tags:
   - coder
@@ -8,6 +8,6 @@ tags:
   - ide
 ---
 
-# Code Server Example
+# code-server Example
 
 This example is maintained by the [Coder](https://coder.com/) team and the source code can be found [here](https://github.com/cdr/deploy-code-server).

--- a/examples/code-server/README.md
+++ b/examples/code-server/README.md
@@ -1,6 +1,6 @@
 ---
 title: code-server
-description: Self-hosted VS Code in the web browser from Coder.
+description: A self-hosted version of code-server from Coder
 buttonSource: https://github.com/cdr/deploy-code-server/blob/main/guides/railway.md
 tags:
   - coder


### PR DESCRIPTION
I noticed the description had it as "code-server," but I made a couple of changes to explain what code-server is and fix the heading. Totally understand if you want to keep the current description, this is just a suggestion :)