### PR TITLE
fix fastapi starter

### DIFF
--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -17,4 +17,4 @@ def get_random(min: Optional[int] = 0, max: Optional[int] = 9):
     return { "value": rval }
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=os.getenv("PORT", default=5000), log_level="info")
+    uvicorn.run("main:app", host="0.0.0.0", port=int(os.getenv("PORT", default=5000)), log_level="info")


### PR DESCRIPTION
Made the port parameter explicitly an integer to fix the `TypeError: %d format: a number is required, not str` error