### PR TITLE
add Cusdis starter

### DIFF
--- a/examples/cusdis/README.md
+++ b/examples/cusdis/README.md
@@ -1,0 +1,12 @@
+---
+title: Cusdis
+description: A self-hosted version of Cusdis using a PostgreSQL database
+buttonSource: https://github.com/railwayapp-starters/cusdis/blob/master/README.md
+tags:
+  - cusdis
+  - postgresql
+---
+
+# Cusdis example
+
+This example is being maintained on the [railwayapp-starters](https://github.com/railwayapp-starters) organization and can be found [here](https://github.com/railwayapp-starters/cusdis).


### PR DESCRIPTION
This PR adds a [Cusdis](https://cusdis.com/) starter to the starters directory on Railway.