### PR TITLE
Bump up Prisma version for Next-Prisma

### DIFF
--- a/examples/nextjs-prisma/package.json
+++ b/examples/nextjs-prisma/package.json
@@ -12,7 +12,7 @@
     "generate": "prisma generate"
   },
   "dependencies": {
-    "@prisma/client": "2.15.0",
+    "@prisma/client": "2.30.0",
     "next": "10.0.6",
     "pg": "^8.5.1",
     "react": "17.0.1",
@@ -20,7 +20,7 @@
     "swr": "^0.4.1"
   },
   "devDependencies": {
-    "@prisma/cli": "2.15.0",
+    "@prisma/cli": "2.30.0",
     "@types/node": "^14.14.22",
     "@types/react": "^17.0.0",
     "typescript": "^4.1.3"


### PR DESCRIPTION
Due to the builder defaulting Node 16, I am bumping the Node version up to 