### PR TITLE
Tweak how Rust Rocket starter builds and runs

### DIFF
--- a/examples/rocket/Dockerfile
+++ b/examples/rocket/Dockerfile
@@ -8,6 +8,6 @@ ENV ROCKET_ENV=staging
 WORKDIR /app
 COPY . .
 
-RUN cargo build
+RUN cargo build --release
 
-CMD ROCKET_PORT=$PORT cargo run
+CMD ROCKET_PORT=$PORT ./target/release/rocket


### PR DESCRIPTION
This PR changes the Rocket starter to build in `--release` mode by default, and to run the outputted binary directly, instead of using `cargo run` which will run the compiler a second time.