### PR TITLE
bumpup deno v1.14.0 and std/http@0.107.0

### DIFF
--- a/examples/deno/Dockerfile
+++ b/examples/deno/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.7.1
+FROM denoland/deno:1.14.0
 
 WORKDIR /app
 

--- a/examples/deno/src/index.ts
+++ b/examples/deno/src/index.ts
@@ -1,10 +1,6 @@
-import { serve } from "https://deno.land/std@0.85.0/http/server.ts";
+import { listenAndServe } from "https://deno.land/std@0.107.0/http/server.ts"
 
-let port = parseInt(Deno.env.get("PORT") ?? "8000")
-const s = serve({ port });
+const port = parseInt(Deno.env.get("PORT") ?? "8000")
+listenAndServe(`:${port}`, () => new Response("Choo Choo! Welcome to your Deno app\n"))
 
 console.log(`http://localhost:${port}/`);
-
-for await (const req of s) {
-  req.respond({ body: "Choo Choo! Welcome to your Deno app\n" });
-}


### PR DESCRIPTION
# description

- deno v1.7.1 to v1.14.0.
- std/http v0.85.0 to v0.107.0.
- Change from old serve function to new listenAndServe function.