### PR TITLE
bumpup 1.16.2 and std/http 0.114.0

### DIFF
--- a/examples/deno/Dockerfile
+++ b/examples/deno/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.14.0
+FROM denoland/deno:1.16.2
 
 WORKDIR /app
 

--- a/examples/deno/src/index.ts
+++ b/examples/deno/src/index.ts
@@ -1,6 +1,7 @@
-import { listenAndServe } from "https://deno.land/std@0.107.0/http/server.ts"
+import { serve } from "https://deno.land/std@0.114.0/http/server.ts"
 
-const port = parseInt(Deno.env.get("PORT") ?? "8000")
-listenAndServe(`:${port}`, () => new Response("Choo Choo! Welcome to your Deno app\n"))
+const port = parseInt(Deno.env.get("PORT") ?? "8000");
+serve(() => new Response("Choo Choo! Welcome to your Deno app\n"),
+      { addr: `:${port}` });
 
 console.log(`http://localhost:${port}/`);


### PR DESCRIPTION
# description

**bumpup**

- deno 1.16.2
- std/http 0.114.0
 
**listenAndServe is Deprecated**

- see: https://github.com/denoland/deno_std/pull/1506
- Fixed to use new function "serve"
