### PR TITLE
Fix openvscode-server exec path

### DIFF
--- a/examples/openvscode-server/Dockerfile
+++ b/examples/openvscode-server/Dockerfile
@@ -1,4 +1,4 @@
 # created by GrimZZZ-404 & Milo123459
 ARG RELEASE_TAG=latest PORT TOKEN
 FROM gitpod/openvscode-server:${RELEASE_TAG}
-ENTRYPOINT [ "/bin/sh", "-c", "exec ${OPENVSCODE_SERVER_ROOT}/server.sh --port ${PORT} --connection-token ${TOKEN}",  "--" ]
+ENTRYPOINT [ "/bin/sh", "-c", "exec ${OPENVSCODE_SERVER_ROOT}/bin/openvscode-server --port ${PORT} --connection-token ${TOKEN}",  "--" ]


### PR DESCRIPTION
This PR updates the executable path for `openvscode-server` to match the upstream. There's an issue in the Discord. As an alternative, I could comment out the `ENTRYPOINT` line altogether and have it inherit from the base image, which appears to still work(ish), based on local Docker testing.

A weird issue is that the URL that it says it's listening on returns no data, but that's probably because I've never used `openvscode-server` before and quite probably misconfigured it.