### PR TITLE
Fastify Starter -> Add build command before running start script

### DIFF
--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "fastify",
-  "version": "1.0.0",
-  "main": "index.js",
-  "author": "Faraz Patankar",
-  "license": "MIT",
-  "scripts": {
-    "dev": "nodemon index.ts",
-    "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js"
-  },
-  "dependencies": {
-    "fastify": "^3.15.1"
-  },
-  "devDependencies": {
-    "@types/node": "^15.6.1",
-    "nodemon": "^2.0.7",
-    "ts-node": "^10.0.0",
-    "typescript": "^4.2.4"
-  }
+    "name": "fastify",
+    "version": "1.0.0",
+    "main": "index.js",
+    "author": "Faraz Patankar",
+    "license": "MIT",
+    "scripts": {
+        "dev": "nodemon index.ts",
+        "build": "tsc -p tsconfig.json",
+        "start": "npm run build && node dist/index.js"
+    },
+    "dependencies": {
+        "fastify": "^3.15.1"
+    },
+    "devDependencies": {
+        "@types/node": "^15.6.1",
+        "nodemon": "^2.0.7",
+        "ts-node": "^10.0.0",
+        "typescript": "^4.2.4"
+    }
 }


### PR DESCRIPTION
The starter fails when trying to deploy to Railway, since the `start` command cannot find the `dist` folder since the `build` hasn't been requested