### PR TITLE
update umami starter to use source repo

### DIFF
--- a/examples/beam/README.md
+++ b/examples/beam/README.md
@@ -8,6 +8,6 @@ tags:
   - typescript
 ---
 
-# Calendso example
+# Beam example
 
 To provide the latest version of Beam, we deploy the code maintained by the [PlanetScale](https://planetscale.com/) team. You can find the source code [here](https://github.com/planetscale/beam).

--- a/examples/umami/README.md
+++ b/examples/umami/README.md
@@ -1,7 +1,6 @@
 ---
 title: Umami
 description: A self-hosted version of Umami using a PostgreSQL database
-buttonSource: https://github.com/railwayapp-starters/umami/blob/master/README.md
 tags:
   - nextjs
   - umami
@@ -11,4 +10,26 @@ tags:
 
 # Umami example
 
-This example has been moved to the [railwayapp-starters](https://github.com/railwayapp-starters) organization and can be found [here](https://github.com/railwayapp-starters/umami).
+To provide the latest version of Umami, we deploy the code maintained by the [Umami](https://umami.is/) team. You can find the source code [here](https://github.com/mikecao/umami).
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/umami)
+
+## ✨ Features
+
+- Umami
+- PostgreSQL
+
+## 💁‍♀️ How to use
+
+- Click the Railway button 👆
+- Add the `HASH_SALT` environment variable and deploy.
+- Clone the project Railway created for you using Git and link your local repo to the Railway project using the [CLI](https://docs.railway.app/develop/cli).
+- Use `railway run psql -h hostname -U username -d databasename -f sql/schema.postgresql.sql` to add all the tables and create the default admin user.
+  - You can view your `hostname`, `username`, and `databasename` using `railway variables` or from your project dashboard.
+  - The default account has the username `admin` and password `umami`. Make sure you change the password after your first login.
+- You should now be able to use the Umami dashboard and add the websites you'd like to track.
+
+## 📝 Notes
+
+- Make sure you [change your password](https://umami.is/docs/login) after you log in for the first time.
+- Read more about [adding a website](https://umami.is/docs/add-a-website) and [collecting data](https://umami.is/docs/collect-data).


### PR DESCRIPTION
The button now uses the new template system and points directly to the source repo. The README also contains instructions on how to use the template.