### PR TITLE
Update svelte starter

### DIFF
--- a/examples/svelte-kit/svelte.config.js
+++ b/examples/svelte-kit/svelte.config.js
@@ -8,7 +8,7 @@ const config = {
 	preprocess: preprocess(),
 
 	kit: {
-		adapter: adapter({ env: { port: process.env.PORT } }),
+		adapter: adapter(),
 
 		// Override http methods in the Todo forms
 		methodOverride: {


### PR DESCRIPTION
The sveltekit config no longer needs to be explicitly told the port environment variable. Fixes #309 