### PR TITLE
Matched Gemfile versions in order to fix build errors

### DIFF
--- a/examples/rails-starter/Gemfile
+++ b/examples/rails-starter/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.4'
+ruby '2.7.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.1.1'

--- a/examples/rails-starter/Gemfile.lock
+++ b/examples/rails-starter/Gemfile.lock
@@ -221,7 +221,7 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.6p219
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
If a ruby version other than 2.7.4 is used, there are startup errors. Matching the Gemfile versions should take care of this.