### PR TITLE
fix button source for aid starter

### DIFF
--- a/examples/aid/README.md
+++ b/examples/aid/README.md
@@ -1,7 +1,7 @@
 ---
 title: AID
 description: Deploy Machine Learning Algorithms from AID Model Hub to Railway
-buttonSource: https://github.com/autoai-incubator/aid-button
+buttonSource: https://github.com/autoai-incubator/aid-button/blob/master/README.md
 tags:
   - machine learning
 ---


### PR DESCRIPTION
The button source was pointing to the repo instead of the README.